### PR TITLE
Only close PIE contexts in OnEndPIE

### DIFF
--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -1,4 +1,4 @@
-﻿#include "ImGuiModule.h"
+#include "ImGuiModule.h"
 
 #include <Widgets/SWindow.h>
 
@@ -100,7 +100,14 @@ TSharedPtr<FImGuiContext> FImGuiModule::FindOrCreateSessionContext(const int32 P
 
 void FImGuiModule::OnEndPIE(bool bIsSimulating)
 {
-	SessionContexts.Reset();
+	for (auto It = SessionContexts.CreateIterator(); It; ++It)
+	{
+		// INDEX_NONE is the key used for the "not in PIE" context, which doesn't need to be removed
+		if (It->Key != INDEX_NONE)
+		{
+			It.RemoveCurrent();
+		}
+	}
 }
 
 TSharedPtr<FImGuiContext> FImGuiModule::CreateWindowContext(const TSharedRef<SWindow>& Window)


### PR DESCRIPTION
When creating ImGui windows from outside of PIE contexts, GPlayInEditorId is -1. This context does not need to be cleaned up when a PIE session ends.