### PR TITLE
Fix Linux compile error in ImGuiModule.cpp

### DIFF
--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -83,7 +83,7 @@ TSharedPtr<FImGuiContext> FImGuiModule::FindOrCreateSessionContext(const int32 P
 
 		if (Context.IsValid())
 		{
-			if (bShouldConnect && !Context->Connect(Host, Port) || bShouldListen && !Context->Listen(Port))
+			if ((bShouldConnect && !Context->Connect(Host, Port)) || (bShouldListen && !Context->Listen(Port)))
 			{
 				Context.Reset();
 				Context = nullptr;


### PR DESCRIPTION
The error in question:

```
[4/9] Compile Module.ImGui.cpp
In file included from [REDACTED]/ImGui/Intermediate/Build/Linux/x64/UnrealServer/Development/ImGui/Module.ImGui.cpp:4:
[REDACTED]\ImGui\Source\ImGui\Private\ImGuiModule.cpp(86,23): error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
                        if (bShouldConnect && !Context->Connect(Host, Port) || bShouldListen && !Context->Listen(Port))
                            ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
[REDACTED]\ImGui\Source\ImGui\Private\ImGuiModule.cpp(86,23): note: place parentheses around the '&&' expression to silence this warning
                        if (bShouldConnect && !Context->Connect(Host, Port) || bShouldListen && !Context->Listen(Port))
                                           ^
                            (                                              )
[REDACTED]\ImGui\Source\ImGui\Private\ImGuiModule.cpp(86,73): error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
                        if (bShouldConnect && !Context->Connect(Host, Port) || bShouldListen && !Context->Listen(Port))
                                                                            ~~ ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
[REDACTED]\ImGui\Source\ImGui\Private\ImGuiModule.cpp(86,73): note: place parentheses around the '&&' expression to silence this warning
                        if (bShouldConnect && !Context->Connect(Host, Port) || bShouldListen && !Context->Listen(Port))
                                                                                             ^
                                                                               (                                      )
2 errors generated.
```