### PR TITLE
Significantly increase draw performance for large numbers of interleaved draw commands

### DIFF
--- a/Source/ImGui/Private/SImGuiOverlay.h
+++ b/Source/ImGui/Private/SImGuiOverlay.h
@@ -59,4 +59,5 @@ private:
 	TSharedPtr<FImGuiContext> Context = nullptr;
 	TSharedPtr<IInputProcessor> InputProcessor = nullptr;
 	FImGuiDrawData DrawData;
+	mutable TArray<bool> UsedCommands;
 };


### PR DESCRIPTION
In our project we draw a significant number of items on a map view using ImGui. Each item consists of several sub-items which in many cases means that each item is split up into several ImGui draw calls (because the `TextureID` changes). 

The problem is now that SImGuiOverlay copies the entire vertex array for each single draw command. With vertex arrays having thousands of entries, this can quickly become a major bottleneck due to constant memory (re-)allocations. 

I didn't find a good way to avoid copying the entire vertex array, but at least we can merge draw calls using the same parameters by merging the index arrays. The worst case I tested with previously took 250 ms per tick(!) to draw everything. With these changes, it now takes 3 ms. This is good enough for us for now, but it's likely that we have to spend some more time there in the future to scale up further.

The main points are:
- Merge draw calls as much as possible to avoid copying the entire vertex array more than we need to
- Avoid calling `FSlateVertex::Make()` and instead inline the required setup which saves additional time
- I also opened a PR to avoid copying the vertex and index arrays when calling `MakeCustomVerts`: https://github.com/EpicGames/UnrealEngine/pull/12023, which also saves a few hundred microseconds with large arrays. However, that repo being what it is, I don't expect this to be merged anytime soon, if ever
- Having `UsedCommands` as a member seems unnecessary at first, but reallocating this all the time in `OnPaint` was actually measurable, so made it a member

This works perfectly for us. Maybe you don't want to take it as is, but I'd love if we could find an agreement here so that we don't have to maintain a divergence in our project