### PR TITLE
Allow materials in TexID

### DIFF
--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -311,14 +311,22 @@ int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGe
 			TArray IndicesSlice(Indices.GetData() + DrawCmd.IdxOffset, DrawCmd.ElemCount);
 
 #if WITH_ENGINE
-			UTexture* Texture = DrawCmd.GetTexID();
-			if (TextureBrush.GetResourceObject() != Texture)
+			UObject* Resource = DrawCmd.GetTexID();
+			if (TextureBrush.GetResourceObject() != Resource)
 			{
-				TextureBrush.SetResourceObject(Texture);
-				if (IsValid(Texture))
+				TextureBrush.SetResourceObject(Resource);
+				if (IsValid(Resource))
 				{
-					TextureBrush.ImageSize.X = Texture->GetSurfaceWidth();
-					TextureBrush.ImageSize.Y = Texture->GetSurfaceHeight();
+					if (UTexture2D* Texture = Cast<UTexture2D>(Resource))
+					{
+						TextureBrush.ImageSize.X = Texture->GetSizeX();
+						TextureBrush.ImageSize.Y = Texture->GetSizeY();						
+					}
+					else
+					{
+						TextureBrush.ImageSize.X = 0;
+						TextureBrush.ImageSize.Y = 0;
+					}
 					TextureBrush.ImageType = ESlateBrushImageType::FullColor;
 					TextureBrush.DrawAs = ESlateBrushDrawType::Image;
 				}

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -319,8 +319,8 @@ int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGe
 				{
 					if (UTexture2D* Texture = Cast<UTexture2D>(Resource))
 					{
-						TextureBrush.ImageSize.X = Texture->GetSizeX();
-						TextureBrush.ImageSize.Y = Texture->GetSizeY();						
+						TextureBrush.ImageSize.X = Texture->GetSurfaceWidth();
+						TextureBrush.ImageSize.Y = Texture->GetSurfaceHeight();
 					}
 					else
 					{


### PR DESCRIPTION
Slate allows us to use texture objects as well as materials when setting up a brush, but the plugin currently always expects it to be a texture.

With this change you can pass in either a `UTexture*` or a `UMaterialInterface*` as the ImGui `TextID`. Since ImGui doesn't care what it is internally (it's just a pointer / uint after all), this works perfectly well, and we just need to cast when actually drawing.

Maybe you want to solve this differently though.