### PR TITLE
Add API for querying registering/unregistering input processor

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -455,6 +455,34 @@ FImGuiContext::operator ImPlotContext*() const
 	return PlotContext;
 }
 
+bool FImGuiContext::IsInputProcessorActive()
+{
+	const FImGuiViewportData* MainViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
+	if (MainViewportData != nullptr && MainViewportData->Overlay.IsValid())
+	{
+		return MainViewportData->Overlay.Pin().Get()->IsInputProcessorActive();
+	}
+	return false;
+}
+
+void FImGuiContext::RegisterInputProcessor()
+{
+	const FImGuiViewportData* MainViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
+	if (MainViewportData != nullptr && MainViewportData->Overlay.IsValid())
+	{
+		MainViewportData->Overlay.Pin().Get()->RegisterInputProcessor();
+	}
+}
+
+void FImGuiContext::UnRegisterInputProcessor()
+{
+	const FImGuiViewportData* MainViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
+	if (MainViewportData != nullptr && MainViewportData->Overlay.IsValid())
+	{
+		MainViewportData->Overlay.Pin().Get()->UnRegisterInputProcessor();
+	}
+}
+
 void FImGuiContext::OnDisplayMetricsChanged(const FDisplayMetrics& DisplayMetrics)
 {
 	ImGui::FScopedContext ScopedContext(AsShared());

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -266,16 +266,38 @@ void SImGuiOverlay::Construct(const FArguments& Args)
 	if (Args._HandleInput)
 	{
 		InputProcessor = MakeShared<FImGuiInputProcessor>(this);
-		FSlateApplication::Get().RegisterInputPreProcessor(InputProcessor.ToSharedRef(), 0);
+		RegisterInputProcessor();
 	}
 }
 
 SImGuiOverlay::~SImGuiOverlay()
 {
-	if (FSlateApplication::IsInitialized() && InputProcessor.IsValid())
+	UnRegisterInputProcessor();
+}
+
+void SImGuiOverlay::RegisterInputProcessor()
+{
+	if (InputProcessor.IsValid() && FSlateApplication::Get().FindInputPreProcessor(InputProcessor) == INDEX_NONE)
+	{
+		FSlateApplication::Get().RegisterInputPreProcessor(InputProcessor.ToSharedRef());
+	}
+}
+
+void SImGuiOverlay::UnRegisterInputProcessor()
+{
+	if (IsInputProcessorActive())
 	{
 		FSlateApplication::Get().UnregisterInputPreProcessor(InputProcessor);
 	}
+}
+
+bool SImGuiOverlay::IsInputProcessorActive() const
+{
+	if (FSlateApplication::IsInitialized() && InputProcessor.IsValid() && FSlateApplication::Get().FindInputPreProcessor(InputProcessor) != INDEX_NONE)
+	{
+		return true;
+	}
+	return false;
 }
 
 int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const

--- a/Source/ImGui/Private/SImGuiOverlay.h
+++ b/Source/ImGui/Private/SImGuiOverlay.h
@@ -47,6 +47,10 @@ public:
 	void Construct(const FArguments& Args);
 	virtual ~SImGuiOverlay() override;
 
+	bool IsInputProcessorActive() const;
+	void RegisterInputProcessor();
+	void UnRegisterInputProcessor();
+
 	virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
 	virtual FVector2D ComputeDesiredSize(float LayoutScaleMultiplier) const override;
 	virtual bool SupportsKeyboardFocus() const override;

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -56,6 +56,10 @@ public:
 	/// Access to the underlying ImPlot context
 	operator ImPlotContext*() const;
 
+	static bool IsInputProcessorActive();
+	static void RegisterInputProcessor();
+	static void UnRegisterInputProcessor();
+
 private:
 	void Initialize();
 


### PR DESCRIPTION
We use these API in a subsystem (that maybe should exist in the root plugin in some form? ) to unregister and register during breakpoints etc.

Some example code:

```
void UDebugGUISubsystem::HandleScriptException(const UObject* InObject, const FFrame& InFrame,
	const FBlueprintExceptionInfo& InInfo)
{
	if (InInfo.GetType() == EBlueprintExceptionType::Breakpoint)
	{
		UnregisterInputProcessor();
	}

	if (InInfo.GetType() == EBlueprintExceptionType::AccessViolation
		|| InInfo.GetType() == EBlueprintExceptionType::AbortExecution
		|| InInfo.GetType() == EBlueprintExceptionType::FatalError )
	{
		DisableGUI();
	}
}
```

```
`void UDebugGUISubsystem::HandlePausePIE(bool bIsSimulating)
{
	UnregisterInputProcessor();
}


void UDebugGUISubsystem::HandleResumePIE(bool bIsSimulating)
{
	RegisterInputProcessor();
}`
```
```

void UDebugGUISubsystem::UnregisterInputProcessor()
{
	if(bDebugGuiOpen && ImGui::GetCurrentContext() != nullptr)
	{
		TSharedPtr<FImGuiContext> ActiveContext = FImGuiContext::Get(ImGui::GetCurrentContext());
		if(ActiveContext.IsValid())
		{
			ActiveContext->UnRegisterInputProcessor();
		}
	}
}

void UDebugGUISubsystem::RegisterInputProcessor()
{
	if(bDebugGuiOpen && ImGui::GetCurrentContext() != nullptr)
	{
		TSharedPtr<FImGuiContext> ActiveContext = FImGuiContext::Get(ImGui::GetCurrentContext());
		if(ActiveContext.IsValid())
		{
			ActiveContext->RegisterInputProcessor();
		}
	}
}
```