### PR TITLE
Add OnInitializeContext delegate

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -21,6 +21,7 @@ THIRD_PARTY_INCLUDES_START
 #include <NetImGui_Api.h>
 THIRD_PARTY_INCLUDES_END
 
+#include "ImGuiModule.h"
 #include "SImGuiOverlay.h"
 
 FImGuiViewportData* FImGuiViewportData::GetOrCreate(ImGuiViewport* Viewport)
@@ -396,6 +397,8 @@ void FImGuiContext::Initialize()
 	{
 		IO.Fonts->AddFontFromFileTTF(TCHAR_TO_UTF8(*FontPath), 16);
 	}
+
+	FImGuiModule::OnInitializeContext.Broadcast();
 
 	if (FSlateApplication::IsInitialized())
 	{

--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -15,6 +15,8 @@
 #include "ImGuiContext.h"
 #include "SImGuiOverlay.h"
 
+FSimpleMulticastDelegate FImGuiModule::OnInitializeContext;
+
 void FImGuiModule::StartupModule()
 {
 #if WITH_EDITOR

--- a/Source/ImGui/Public/ImGuiModule.h
+++ b/Source/ImGui/Public/ImGuiModule.h
@@ -2,6 +2,7 @@
 
 #include <Misc/EngineVersionComparison.h>
 #include <Modules/ModuleManager.h>
+#include <Delegates/Delegate.h>
 
 class FImGuiContext;
 class SWindow;
@@ -30,6 +31,8 @@ public:
 
 	/// Creates an ImGui context for a game viewport
 	static TSharedPtr<FImGuiContext> CreateViewportContext(UGameViewportClient* GameViewport);
+
+	static FSimpleMulticastDelegate OnInitializeContext;
 
 private:
 	void OnEndPIE(bool bIsSimulating);


### PR DESCRIPTION
Hello,

This has been a simple way where I work to inject ImGui init code into the plugin, for now we're using it to load [icons](https://github.com/juliettef/IconFontCppHeaders) into the ImGui font.

I was wondering if passing `FImGuiContext*` to the delegate would be relevant (it isn't in our case but maybe in the future).

Do tell me how you'd rather do things.