### PR TITLE
Forward declarations for ImTextureID

### DIFF
--- a/Source/ImGui/Public/ImGuiConfig.h
+++ b/Source/ImGui/Public/ImGuiConfig.h
@@ -60,6 +60,8 @@ struct ImGuiContext;
 struct ImPlotContext;
 enum ImGuiKey : int;
 struct FKey;
+class UTexture;
+struct FSlateBrush;
 
 namespace ImGui
 {


### PR DESCRIPTION
Hello,

While trying to use `ImGui::Image` in our code we realized that the `ImTextureID`'s underlying types were not forward declared to `imgui.h`, which meant that the functions using that type were declared with a forward declaration *inside the ImGui namespace* (i.e. `ImGui::UTexture`). In effect it wasn't possible to call `ImGui::Image` with a plain `UTexture*` because the types didn't match. These simple forward declarations fixed it.