### PR TITLE
Changes to support Global Invalidation

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -94,6 +94,7 @@ static void ImGui_CreateWindow(ImGuiViewport* Viewport)
 				SAssignNew(ViewportData->Overlay, SImGuiOverlay)
 				.Context(FImGuiContext::Get(ImGui::GetCurrentContext()))
 				.HandleInput(false)
+				.ForceVolatile(true)
 			];
 
 		if (ParentWindow.IsValid())

--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -143,7 +143,7 @@ void FImGuiModule::OnViewportCreated() const
 	FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
 	if (ViewportData && !ViewportData->Overlay.IsValid())
 	{
-		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context);
+		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context).ForceVolatile(true);
 
 		ViewportData->Window = GameViewport->GetWindow();
 		ViewportData->Overlay = Overlay;
@@ -162,7 +162,7 @@ TSharedPtr<FImGuiContext> FImGuiModule::CreateWindowContext(const TSharedRef<SWi
 	FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
 	if (ViewportData)
 	{
-		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context);
+		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context).ForceVolatile(true);
 
 		ViewportData->Window = Window;
 		ViewportData->Overlay = Overlay;
@@ -188,7 +188,7 @@ TSharedPtr<FImGuiContext> FImGuiModule::CreateViewportContext(UGameViewportClien
 	FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
 	if (ViewportData)
 	{
-		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context);
+		const TSharedRef<SImGuiOverlay> Overlay = SNew(SImGuiOverlay).Context(Context).ForceVolatile(true);
 
 		ViewportData->Window = GameViewport->GetWindow();
 		ViewportData->Overlay = Overlay;


### PR DESCRIPTION
Sets the SImGuiOverlay widget as volatile, preventing the Invalidation system from caching its Paint data and ultimately forcing OnPaint to be called every frame.