### PR TITLE
SImGuiOverlay changes to support Global Invalidation

### DIFF
--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -224,6 +224,7 @@ private:
 void SImGuiOverlay::Construct(const FArguments& Args)
 {
 	SetVisibility(EVisibility::HitTestInvisible);
+	ForceVolatile(true);
 
 	Context = Args._Context.IsValid() ? Args._Context : FImGuiContext::Create();
 	if (Args._HandleInput)


### PR DESCRIPTION
Sets the SImGuiOverlay widget as volatile, preventing the Invalidation system from caching its Paint data and ultimately forcing OnPaint to be called every frame.