### PR TITLE
Fix touch-control support for mobile

### DIFF
--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -156,6 +156,8 @@ public:
 
 		ImGuiIO& IO = ImGui::GetIO();
 
+		IO.AddMouseSourceEvent(Event.IsTouchEvent() ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
+
 		if (SlateApp.HasAnyMouseCaptor())
 		{
 			IO.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
@@ -185,6 +187,17 @@ public:
 
 		ImGuiIO& IO = ImGui::GetIO();
 
+		if (Event.IsTouchEvent())
+		{
+			IO.AddMouseSourceEvent(ImGuiMouseSource_TouchScreen);
+			const FVector2f Position = Event.GetScreenSpacePosition();
+			IO.AddMousePosEvent(Position.X, Position.Y);
+		}
+		else
+		{
+			IO.AddMouseSourceEvent(ImGuiMouseSource_Mouse);
+		}
+
 		const FKey Button = Event.GetEffectingButton();
 		if (Button == EKeys::LeftMouseButton)
 		{
@@ -212,6 +225,8 @@ public:
 		ImGui::FScopedContext ScopedContext(Owner->GetContext());
 
 		ImGuiIO& IO = ImGui::GetIO();
+
+		IO.AddMouseSourceEvent(Event.IsTouchEvent() ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
 
 		const FKey Button = Event.GetEffectingButton();
 		if (Button == EKeys::LeftMouseButton)


### PR DESCRIPTION
Touch-events don't have intermediate move-events leading up to it like a mouse does. In the case of a touch-down event, an additional MousePos event needs to be dispatched ahead of the MouseButton event to position the cursor properly before registering the button-down event.