### PR TITLE
#AllowImGuiIni

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -371,7 +371,7 @@ void FImGuiContext::Initialize()
 #endif
 
 	// Ensure each PIE session has a uniquely identifiable context
-	const FString ContextName = (PieSessionId > 0 ? FString::Printf(TEXT("ImGui_%d"), PieSessionId) : TEXT("ImGui"));
+	const FString ContextName = (PieSessionId > 0 ? FString::Printf(TEXT("ImGuiGameUserSettings_%d"), PieSessionId) : TEXT("ImGuiGameUserSettings"));
 
 	const FString IniFilename = FPaths::GeneratedConfigDir() / FPlatformProperties::PlatformName() / ContextName + TEXT(".ini");
 	FPlatformString::Convert(reinterpret_cast<UTF8CHAR*>(IniFilenameUtf8), UE_ARRAY_COUNT(IniFilenameUtf8), *IniFilename, IniFilename.Len() + 1);

--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -371,7 +371,7 @@ void FImGuiContext::Initialize()
 #endif
 
 	// Ensure each PIE session has a uniquely identifiable context
-	const FString ContextName = (PieSessionId > 0 ? FString::Printf(TEXT("ImGui_%d"), PieSessionId) : TEXT("ImGui"));
+	const FString ContextName = (GPlayInEditorID > 0 ? FString::Printf(TEXT("ImGuiGameUserSettings_%d"), static_cast<int32>(GPlayInEditorID)) : TEXT("ImGuiGameUserSettings"));
 
 	const FString IniFilename = FPaths::GeneratedConfigDir() / FPlatformProperties::PlatformName() / ContextName + TEXT(".ini");
 	FPlatformString::Convert(reinterpret_cast<UTF8CHAR*>(IniFilenameUtf8), UE_ARRAY_COUNT(IniFilenameUtf8), *IniFilename, IniFilename.Len() + 1);

--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -371,7 +371,7 @@ void FImGuiContext::Initialize()
 #endif
 
 	// Ensure each PIE session has a uniquely identifiable context
-	const FString ContextName = (GPlayInEditorID > 0 ? FString::Printf(TEXT("ImGuiGameUserSettings_%d"), static_cast<int32>(GPlayInEditorID)) : TEXT("ImGuiGameUserSettings"));
+	const FString ContextName = (PieSessionId > 0 ? FString::Printf(TEXT("ImGui_%d"), PieSessionId) : TEXT("ImGui"));
 
 	const FString IniFilename = FPaths::GeneratedConfigDir() / FPlatformProperties::PlatformName() / ContextName + TEXT(".ini");
 	FPlatformString::Convert(reinterpret_cast<UTF8CHAR*>(IniFilenameUtf8), UE_ARRAY_COUNT(IniFilenameUtf8), *IniFilename, IniFilename.Len() + 1);


### PR DESCRIPTION
When DISABLE_NONUFS_INI_WHEN_COOKED is defined, FPakPlatformFile::IsNonPakFilenameAllowed rejects all free .ini files except for GameUserSettings.ini via a relatively hacky code path. ImGui.ini is effectively ImGui's equivalent, so we can piggyback off of this, and read our file in packaged builds, if we name it ImGuiGameUserSettings.ini

It does cause a breaking change to the file in Editor (I could go either way on that). But... if you don't name it this in packaged builds, it can't follow the allowlist codepath. So you can't have any imgui settings in builds that disable non ufs inis