### PR TITLE
Disable viewports outside of desktop platforms

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -360,8 +360,10 @@ void FImGuiContext::Initialize()
 
 	IO.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
 	IO.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
+#if PLATFORM_DESKTOP
 	IO.BackendFlags |= ImGuiBackendFlags_PlatformHasViewports;
 	IO.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;
+#endif
 	IO.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;
 
 #if UE_VERSION_OLDER_THAN(5, 5, 0)


### PR DESCRIPTION
Hello,

We've had issues on consoles because ImGui tried creating windows (assert in `FXboxCommonApplication::InitializeWindow`). This change disables viewports for non-desktop platforms. I've tested it on Windows and XSX.

Hope this helps :)