### PR TITLE
Add ImGui .natvis and .natstepfilter

### DIFF
--- a/Source/ImGui/imgui.natstepfilter
+++ b/Source/ImGui/imgui.natstepfilter
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+.natstepfilter file for Visual Studio debugger.
+Purpose: instruct debugger to skip some functions when using StepInto (F11)
+
+Since Visual Studio 2022 version 17.6 Preview 2 (currently available as a "Preview" build on March 14, 2023)
+It is possible to add the .natstepfilter file to your project file and it will automatically be used.
+(https://developercommunity.visualstudio.com/t/allow-natstepfilter-and-natjmc-to-be-included-as-p/561718)
+
+For older Visual Studio version prior to 2022 17.6 Preview 2:
+* copy in %USERPROFILE%\Documents\Visual Studio XXXX\Visualizers (current user)
+* or copy in %VsInstallDirectory%\Common7\Packages\Debugger\Visualizers (all users)
+If you have multiple VS version installed, the version that matters is the one you are using the IDE/debugger
+of (not the compiling toolset). This is supported since Visual Studio 2012.
+
+More information at: https://docs.microsoft.com/en-us/visualstudio/debugger/just-my-code?view=vs-2019#BKMK_C___Just_My_Code
+-->
+
+<StepFilter xmlns="http://schemas.microsoft.com/vstudio/debugger/natstepfilter/2010">
+
+    <!-- Disable stepping into trivial functions -->
+    <Function>
+        <Name>(ImVec2|ImVec4|ImStrv)::.+</Name>
+        <Action>NoStepInto</Action>
+    </Function>
+    <Function>
+        <Name>(ImVector|ImSpan).*::operator.+</Name>
+        <Action>NoStepInto</Action>
+    </Function>
+
+</StepFilter>

--- a/Source/ImGui/imgui.natvis
+++ b/Source/ImGui/imgui.natvis
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+.natvis file for Visual Studio debugger.
+Purpose: provide nicer views on data types used by Dear ImGui.
+
+To enable:
+* include file in your VS project (most recommended: not intrusive and always kept up to date!)
+* or copy in %USERPROFILE%\Documents\Visual Studio XXXX\Visualizers (current user)
+* or copy in %VsInstallDirectory%\Common7\Packages\Debugger\Visualizers (all users)
+
+More information at: https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2019
+-->
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+<Type Name="ImVector&lt;*&gt;">
+  <DisplayString>{{Size={Size} Capacity={Capacity}}}</DisplayString>
+  <Expand>
+    <ArrayItems>
+      <Size>Size</Size>
+      <ValuePointer>Data</ValuePointer>
+    </ArrayItems>
+  </Expand>
+</Type>
+
+<Type Name="ImSpan&lt;*&gt;">
+  <DisplayString>{{Size={DataEnd-Data} }}</DisplayString>
+  <Expand>
+    <ArrayItems>
+      <Size>DataEnd-Data</Size>
+      <ValuePointer>Data</ValuePointer>
+    </ArrayItems>
+  </Expand>
+</Type>
+
+<Type Name="ImVec2">
+  <DisplayString>{{x={x,g} y={y,g}}}</DisplayString>
+</Type>
+
+<Type Name="ImVec4">
+  <DisplayString>{{x={x,g} y={y,g} z={z,g} w={w,g}}}</DisplayString>
+</Type>
+
+<Type Name="ImRect">
+  <DisplayString>{{Min=({Min.x,g} {Min.y,g}) Max=({Max.x,g} {Max.y,g}) Size=({Max.x-Min.x,g} {Max.y-Min.y,g})}}</DisplayString>
+  <Expand>
+    <Item Name="Min">Min</Item>
+    <Item Name="Max">Max</Item>
+    <Item Name="[Width]">Max.x - Min.x</Item>
+    <Item Name="[Height]">Max.y - Min.y</Item>
+  </Expand>
+</Type>
+
+<Type Name="ImGuiWindow">
+  <DisplayString>{{Name {Name,s} Active {(Active||WasActive)?1:0,d} Child {(Flags &amp; 0x01000000)?1:0,d} Popup {(Flags &amp; 0x04000000)?1:0,d} Hidden {(Hidden)?1:0,d}}</DisplayString>
+</Type>
+
+</AutoVisualizer>


### PR DESCRIPTION
Hello,

We noticed that the `.natvis` files for ImGui (found [here](https://github.com/ocornut/imgui/tree/master/misc/debuggers)) weren't in the plugin even though they can be pretty useful for debugging. They only need to be put in a module directory to be loaded automatically by the Unreal solution.

Hopefully this can be useful to other people too :)