### PR TITLE
Fix bug that causes floating viewports to resize to (0,0) when clicking the bottom-right corner and dragging out to make viewport bigger.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Binaries/
 Intermediate/
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 Binaries/
 Intermediate/
-.vs/

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -183,7 +183,7 @@ public:
 				TargetViewport = FindViewportForWindow(LastWidgetsUnderPointer.Window.Pin());
 			}
 
-			if (!TargetViewport && !ImGui::IsMouseDragging(0))
+			if (!TargetViewport && !ImGui::IsMouseDown(0))
 			{
 				IO.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
 				return false;


### PR DESCRIPTION
ImGui::IsMouseDragging(0) only returns true once mouse has moved 6 pixels.  When resizing a viewport, user can click on the corner and move the mouse less than 6 pixels to leave the viewport.  That would then cause the viewport to resize to (0,0).  ImGui::IsMouseDown(0) does not suffer this problem and does not appear to cause any other issues.