### PR TITLE
Fix inability to type non-ANSI characters into text input widgets

### DIFF
--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -448,7 +448,7 @@ FReply SImGuiOverlay::OnKeyChar(const FGeometry& MyGeometry, const FCharacterEve
 
 	ImGuiIO& IO = ImGui::GetIO();
 
-	IO.AddInputCharacter(CharCast<ANSICHAR>(Event.GetCharacter()));
+	IO.AddInputCharacter(Event.GetCharacter());
 
 	return IO.WantTextInput ? FReply::Handled() : FReply::Unhandled();
 }


### PR DESCRIPTION
There is no need to cast characters to `ANSICHAR` as `ImGuiIO::AddInputCharacter()` can also accept `TCHAR` without any problems.