### PR TITLE
Fix a crash when stopping multiple PIE sessions at the same time

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -447,8 +447,13 @@ FImGuiContext::~FImGuiContext()
 			}
 		}
 
+		ImGuiContext* PreviousContext = ImGui::GetCurrentContext();
+		ImGui::SetCurrentContext(Context);
+
 		ImGui::DestroyPlatformWindows();
-		ImGui::DestroyContext(Context);
+		ImGui::DestroyContext();
+
+		ImGui::SetCurrentContext(PreviousContext);
 		Context = nullptr;
 	}
 }


### PR DESCRIPTION
`ImGui::DestroyPlatformWindows()` uses `GImGui`, so we need to make sure it is correct, which is not the case with `FImGuiContext::~FImGuiContext()`, since it does not change the context.