### PR TITLE
Ignore input if the game viewport is not in the focus path

### DIFF
--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -149,6 +149,7 @@ void FImGuiModule::OnViewportCreated() const
 
 		ViewportData->Window = GameViewport->GetWindow();
 		ViewportData->Overlay = Overlay;
+		ViewportData->Viewport = GameViewport->GetGameViewportWidget();
 
 		GameViewport->AddViewportWidgetContent(Overlay, TNumericLimits<int32>::Max());
 	}
@@ -194,6 +195,7 @@ TSharedPtr<FImGuiContext> FImGuiModule::CreateViewportContext(UGameViewportClien
 
 		ViewportData->Window = GameViewport->GetWindow();
 		ViewportData->Overlay = Overlay;
+		ViewportData->Viewport = GameViewport->GetGameViewportWidget();
 
 		GameViewport->AddViewportWidgetContent(Overlay, TNumericLimits<int32>::Max());
 	}

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -1,8 +1,10 @@
 ﻿#include "SImGuiOverlay.h"
 
 #include <Framework/Application/SlateApplication.h>
+#include <Framework/Application/SlateUser.h>
 
 #include "ImGuiContext.h"
+#include "Widgets/SViewport.h"
 
 FImGuiDrawList::FImGuiDrawList(ImDrawList* Source)
 {
@@ -293,7 +295,24 @@ public:
 		if (Event.IsKeyEvent())
 		{
 			const FImGuiViewportData* FocusedViewport = FindViewportForWindow(LastFocusedWindow.Pin());
+
+#if PLATFORM_DESKTOP
+			if (FocusedViewport == nullptr)
+			{
+				return false;
+			}
+
+			const TSharedPtr<FSlateUser> SlateUser = SlateApp.GetUser(Event);
+			const TSharedPtr<SViewport> Viewport = FocusedViewport->Viewport.Pin();
+
+			if (SlateUser.IsValid() && Viewport.IsValid())
+			{
+				// Ignore input if the game viewport is not in the focus path.
+				return SlateUser->IsWidgetInFocusPath(Viewport);
+			}
+#else
 			return FocusedViewport != nullptr;
+#endif
 		}
 
 		return true;

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -9,6 +9,7 @@
 
 class SWindow;
 class SImGuiOverlay;
+class SViewport;
 struct FDisplayMetrics;
 struct FSlateBrush;
 struct ImGuiContext;
@@ -23,6 +24,7 @@ struct IMGUI_API FImGuiViewportData
 
 	TWeakPtr<SWindow> Window = nullptr;
 	TWeakPtr<SImGuiOverlay> Overlay = nullptr;
+	TWeakPtr<SViewport> Viewport = nullptr;
 };
 
 class IMGUI_API FImGuiContext : public TSharedFromThis<FImGuiContext>


### PR DESCRIPTION
This fixes issues where Dear ImGui continues to react to shortcuts in PIE, even when the game viewport is not in focus.

Common UI works similarly, see `FCommonAnalogCursor::IsRelevantInput()`.