### PR TITLE
Add partial support for custom mouse cursors

### DIFF
--- a/Source/ImGui/Private/ImGuiConfig.cpp
+++ b/Source/ImGui/Private/ImGuiConfig.cpp
@@ -4,6 +4,7 @@
 
 #include <InputCoreTypes.h>
 #include <Framework/Commands/InputChord.h>
+#include <GenericPlatform/ICursor.h>
 #include <HAL/PlatformFileManager.h>
 
 #if WITH_ENGINE
@@ -496,6 +497,49 @@ FInputChord ImGui::ConvertKeyChord(const ImGuiKeyChord Chord)
 	Result.bCmd = (Chord & ImGuiMod_Super) != 0;
 
 	return Result;
+}
+
+EMouseCursor::Type ImGui::ConvertMouseCursor(const ImGuiMouseCursor Cursor)
+{
+	switch (Cursor)
+	{
+		case ImGuiMouseCursor_None:
+			return EMouseCursor::None;
+
+		case ImGuiMouseCursor_Arrow:
+			return EMouseCursor::Default;
+
+		case ImGuiMouseCursor_TextInput:
+			return EMouseCursor::TextEditBeam;
+
+		case ImGuiMouseCursor_ResizeAll:
+			return EMouseCursor::CardinalCross;
+
+		case ImGuiMouseCursor_ResizeNS:
+			return EMouseCursor::ResizeUpDown;
+
+		case ImGuiMouseCursor_ResizeEW:
+			return EMouseCursor::ResizeLeftRight;
+
+		case ImGuiMouseCursor_ResizeNESW:
+			return EMouseCursor::ResizeSouthWest;
+
+		case ImGuiMouseCursor_ResizeNWSE:
+			return EMouseCursor::ResizeSouthEast;
+
+		case ImGuiMouseCursor_Hand:
+			return EMouseCursor::Hand;
+
+		case ImGuiMouseCursor_Wait:
+		case ImGuiMouseCursor_Progress:
+			return EMouseCursor::Default;
+
+		case ImGuiMouseCursor_NotAllowed:
+			return EMouseCursor::SlashedCircle;
+
+		default:
+			return EMouseCursor::Default;
+	}
 }
 
 #endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -67,15 +67,17 @@ static void ImGui_CreateWindow(ImGuiViewport* Viewport)
 	FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(Viewport);
 	if (ViewportData)
 	{
+		const TSharedPtr<FImGuiContext> Context = FImGuiContext::Get(ImGui::GetCurrentContext());
 		const FImGuiViewportData* MainViewportData = FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
 		const TSharedPtr<SWindow> ParentWindow = MainViewportData ? MainViewportData->Window.Pin() : nullptr;
 
 		const TSharedRef<SWindow> Window =
 			SAssignNew(ViewportData->Window, SImGuiWindow)
 			.Viewport(Viewport)
+			.Context(Context)
 			[
 				SAssignNew(ViewportData->Overlay, SImGuiOverlay)
-				.Context(FImGuiContext::Get(ImGui::GetCurrentContext()))
+				.Context(Context)
 				.HandleInput(false)
 			];
 
@@ -530,6 +532,11 @@ FImGuiContext::operator ImPlotContext*() const
 }
 #endif
 
+ImGuiMouseCursor FImGuiContext::GetLastMouseCursor() const
+{
+	return LastMouseCursor;
+}
+
 void FImGuiContext::OnDisplayMetricsChanged(const FDisplayMetrics& DisplayMetrics)
 {
 	ImGui::FScopedContext ScopedContext(AsShared());
@@ -711,6 +718,8 @@ void FImGuiContext::EndFrame()
 	}
 
 	ImGui::FScopedContext ScopedContext(AsShared());
+
+	LastMouseCursor = ImGui::GetMouseCursor();
 
 	ImGui::Render();
 	ImGui::UpdatePlatformWindows();

--- a/Source/ImGui/Private/SImGuiWindow.cpp
+++ b/Source/ImGui/Private/SImGuiWindow.cpp
@@ -6,8 +6,12 @@ THIRD_PARTY_INCLUDES_START
 #include <imgui.h>
 THIRD_PARTY_INCLUDES_END
 
+#include "ImGuiContext.h"
+
 void SImGuiWindow::Construct(const FArguments& Args)
 {
+	Context = Args._Context.IsValid() ? Args._Context : FImGuiContext::Create();
+
 	const bool bTooltipWindow = (Args._Viewport->Flags & ImGuiViewportFlags_TopMost);
 	const bool bPopupWindow = (Args._Viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon);
 	const bool bNoFocusOnAppearing = (Args._Viewport->Flags & ImGuiViewportFlags_NoFocusOnAppearing);
@@ -56,6 +60,11 @@ bool SImGuiWindow::OnIsActiveChanged(const FWindowActivateEvent& ActivateEvent)
 	}
 
 	return SWindow::OnIsActiveChanged(ActivateEvent);
+}
+
+FCursorReply SImGuiWindow::OnCursorQuery(const FGeometry& MyGeometry, const FPointerEvent& CursorEvent) const
+{
+	return FCursorReply::Cursor(ImGui::ConvertMouseCursor(Context->GetLastMouseCursor()));
 }
 
 #endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/SImGuiWindow.h
+++ b/Source/ImGui/Private/SImGuiWindow.h
@@ -5,6 +5,7 @@
 #include <Widgets/SWindow.h>
 
 struct ImGuiViewport;
+class FImGuiContext;
 
 class SImGuiWindow : public SWindow
 {
@@ -13,12 +14,18 @@ class SImGuiWindow : public SWindow
 		}
 
 		SLATE_ARGUMENT(ImGuiViewport*, Viewport);
+		SLATE_ARGUMENT(TSharedPtr<FImGuiContext>, Context);
 		SLATE_DEFAULT_SLOT(FArguments, Content);
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& Args);
 
 	virtual bool OnIsActiveChanged(const FWindowActivateEvent& ActivateEvent) override;
+
+	virtual FCursorReply OnCursorQuery(const FGeometry& MyGeometry, const FPointerEvent& CursorEvent) const override;
+
+private:
+	TSharedPtr<FImGuiContext> Context = nullptr;
 };
 
 #endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Public/ImGuiConfig.h
+++ b/Source/ImGui/Public/ImGuiConfig.h
@@ -17,8 +17,14 @@ struct FKey;
 struct FSlateBrush;
 enum ImGuiKey : int;
 typedef int ImGuiKeyChord;
+typedef int ImGuiMouseCursor;
 struct ImGuiContext;
 struct ImPlotContext;
+
+namespace EMouseCursor
+{
+	enum Type : int;
+}
 
 #define IM_ASSERT(Expr) ensure(Expr)
 
@@ -125,6 +131,9 @@ namespace ImGui
 
 	/// Converts from ImGui to UE key chord
 	IMGUI_API FInputChord ConvertKeyChord(const ImGuiKeyChord Chord);
+
+	/// Converts from ImGui to UE mouse cursor
+	IMGUI_API EMouseCursor::Type ConvertMouseCursor(const ImGuiMouseCursor Cursor);
 }
 
 #define IMGUI_INCLUDE_IMGUI_USER_H

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -17,6 +17,7 @@ struct ImGuiContext;
 struct ImGuiViewport;
 struct ImPlotContext;
 struct ImTextureData;
+typedef int ImGuiMouseCursor;
 
 struct IMGUI_API FImGuiViewportData
 {
@@ -63,6 +64,8 @@ public:
 	operator ImPlotContext*() const;
 #endif
 
+	ImGuiMouseCursor GetLastMouseCursor() const;
+
 private:
 	void Initialize();
 
@@ -93,6 +96,8 @@ private:
 #endif
 
 	TArray<FTextureRef> Textures;
+
+	ImGuiMouseCursor LastMouseCursor = 0;
 };
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
This PR adds support for custom mouse cursors, but only for InGui windows.

To implement custom mouse cursors inside the game viewport, a custom `UGameViewportClient` with overridden `GetCursor()` and `IsInPermanentCapture()` functions is required. Here is an unedited code from my project that can be used as an example:

```cpp
EMouseCursor::Type ULmGameViewportClient::GetCursor(FViewport* InViewport, const int32 MouseX, const int32 MouseY)
{
#ifndef IMGUI_DISABLE
	const auto MouseCursor{Super::GetCursor(InViewport, MouseX, MouseY)};
	if (MouseCursor != EMouseCursor::None && MouseCursor != EMouseCursor::Default)
	{
		return MouseCursor;
	}

	const auto* DebuggerSubsystem{ULmDebuggerSubsystem::Get(GetWorld())};
	if (!IsValid(DebuggerSubsystem) || !DebuggerSubsystem->IsDebuggerEnabled())
	{
		return MouseCursor;
	}

	if (DebuggerSubsystem->IsGameInputAllowed() && MouseCursor == EMouseCursor::None)
	{
		// Preserve cursor visibility if input is not enabled.
		return MouseCursor;
	}

	const auto& WorldContext{GEngine->GetWorldContextFromGameViewportChecked(this)};
	const ImGui::FScopedContext ImGuiContext{WorldContext.PIEInstance};

	if (!ImGuiContext)
	{
		return MouseCursor;
	}

	return ImGui::ConvertMouseCursor(ImGuiContext->GetLastMouseCursor());
#else
	return Super::GetCursor(InViewport, MouseX, MouseY);
#endif
}

bool ULmGameViewportClient::IsInPermanentCapture()
{
#ifndef IMGUI_DISABLE
	const auto* DebuggerSubsystem{ULmDebuggerSubsystem::Get(GetWorld())};
	if (IsValid(DebuggerSubsystem) && !DebuggerSubsystem->IsGameInputAllowed())
	{
		return false;
	}
#endif

	return Super::IsInPermanentCapture();
}
```