### PR TITLE
Improve NetImgui integration

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -454,7 +454,7 @@ FImGuiContext::~FImGuiContext()
 }
 
 #if WITH_NETIMGUI
-bool FImGuiContext::Listen(uint16 Port)
+bool FImGuiContext::Listen(uint32 Port)
 {
 	ImGui::FScopedContext ScopedContext(AsShared());
 
@@ -472,13 +472,10 @@ bool FImGuiContext::Listen(uint16 Port)
 		ClientName << " (" << PieSessionId << ")";
 	}
 
-	NetImgui::ConnectFromApp(ClientName.ToString(), Port);
-	bIsRemote = true;
-
-	return true;
+	return NetImgui::ConnectFromApp(ClientName.ToString(), Port);
 }
 
-bool FImGuiContext::Connect(const FString& Host, int16 Port)
+bool FImGuiContext::Connect(const FString& Host, uint32 Port)
 {
 	ImGui::FScopedContext ScopedContext(AsShared());
 
@@ -496,19 +493,12 @@ bool FImGuiContext::Connect(const FString& Host, int16 Port)
 		ClientName << " (" << PieSessionId << ")";
 	}
 
-	NetImgui::ConnectToApp(ClientName.ToString(), TCHAR_TO_ANSI(*Host), Port);
-	bIsRemote = true;
-
-	return true;
+	return NetImgui::ConnectToApp(ClientName.ToString(), TCHAR_TO_ANSI(*Host), Port);
 }
 
 void FImGuiContext::Disconnect()
 {
-	if (bIsRemote)
-	{
-		NetImgui::Disconnect();
-		bIsRemote = false;
-	}
+	NetImgui::Disconnect();
 }
 #endif
 
@@ -680,13 +670,6 @@ void FImGuiContext::BeginFrame()
 		return;
 	}
 
-#if WITH_NETIMGUI
-	if (bIsRemote && !NetImgui::IsConnected())
-	{
-		return;
-	}
-#endif
-
 	ImGui::FScopedContext ScopedContext(AsShared());
 
 	ImGuiIO& IO = ImGui::GetIO();
@@ -707,7 +690,6 @@ void FImGuiContext::EndFrame()
 	ImGui::FScopedContext ScopedContext(AsShared());
 
 	ImGui::Render();
-	ImGui::UpdatePlatformWindows();
 
 	for (ImTextureData* TextureData : ImGui::GetPlatformIO().Textures)
 	{
@@ -725,11 +707,11 @@ void FImGuiContext::EndFrame()
 		}
 	}
 
-#if WITH_NETIMGUI
-	if (!bIsRemote)
-#endif
+	ImGui_RenderWindow(ImGui::GetMainViewport(), nullptr);
+
+	if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
 	{
-		ImGui_RenderWindow(ImGui::GetMainViewport(), nullptr);
+		ImGui::UpdatePlatformWindows();
 		ImGui::RenderPlatformWindowsDefault();
 	}
 }

--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -86,22 +86,20 @@ TSharedPtr<FImGuiContext> FImGuiModule::FindOrCreateSessionContext(const int32 P
 			uint16 Port = bShouldConnect ? 8888 : 8889;
 			const bool bShouldListen = FParse::Value(FCommandLine::Get(), TEXT("-ImGuiPort="), Port) && Port != 0;
 
-			if (!bShouldConnect)
+			if (bShouldConnect)
+			{
+				Context->Connect(Host, Port);
+			}
+			else if (bShouldListen)
 			{
 				// Bind consecutive listen ports for PIE sessions
 				Port += PieSessionId + 1;
-			}
 
-			if ((bShouldConnect && !Context->Connect(Host, Port)) || (bShouldListen && !Context->Listen(Port)))
-			{
-				Context.Reset();
-				Context = nullptr;
+				Context->Listen(Port);
 			}
-			else
 #endif
-			{
-				SessionContexts.Add(PieSessionId, Context);
-			}
+
+			SessionContexts.Add(PieSessionId, Context);
 		}
 	}
 

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -44,10 +44,10 @@ public:
 
 #if WITH_NETIMGUI
 	/// Listens for remote connections
-	bool Listen(uint16 Port);
+	bool Listen(uint32 Port);
 
 	/// Connects to a remote host
-	bool Connect(const FString& Host, int16 Port);
+	bool Connect(const FString& Host, uint32 Port);
 
 	/// Closes all remote connections
 	void Disconnect();
@@ -79,10 +79,6 @@ private:
 	char IniFilenameUtf8[1024] = {};
 	char LogFilenameUtf8[1024] = {};
 	TArray<char> ClipboardBuffer;
-
-#if WITH_NETIMGUI
-	bool bIsRemote = false;
-#endif
 
 #if WITH_ENGINE
 	using FTextureRef = TStrongObjectPtr<UTexture>;


### PR DESCRIPTION
1. Fixed incorrect types used for ports in `FImGuiContext::Listen()` and `FImGuiContext::Connect()`.
2. Removed `bIsRemote` as it only causes problems:
    - It prevents ImGui from rendering, even if we are not connected to the server yet.
    - ImGui remains hidden if the server initiated a disconnection (user clicked the "X" button on the client tab in the server window).
3. Added a check for the `ImGuiConfigFlags_ViewportsEnable` flag before calling `ImGui::UpdatePlatformWindows()`, which fixes an ensure after disconnecting from the server.
4. Removed `Context.Reset();` from `FImGuiModule::FindOrCreateSessionContext()`, as it makes ImGui unusable if it fails to connect to the server.