### PR TITLE
Fix: Hover and clicks stop due to interaction with other Slate windows

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -337,6 +337,7 @@ void FImGuiContext::Initialize()
 
 	IO.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
 	IO.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
+	IO.BackendFlags |= ImGuiBackendFlags_HasMouseHoveredViewport;
 	IO.BackendFlags |= ImGuiBackendFlags_PlatformHasViewports;
 	IO.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;
 	IO.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -177,12 +177,17 @@ public:
 		const TSharedPtr<FSlateUser> SlateUser = SlateApp.GetUser(Event.GetUserIndex());
 		if (SlateUser.IsValid())
 		{
-			const FImGuiViewportData* TargetViewport = nullptr;
+			const ImGuiViewport* TargetViewport = nullptr;
 
 			if (!SlateUser->HasCapture(Event.GetPointerIndex()))
 			{
 				const FWeakWidgetPath LastWidgetsUnderPointer = SlateUser->GetLastWidgetsUnderPointer(Event.GetPointerIndex());
 				TargetViewport = FindViewportForWindow(LastWidgetsUnderPointer.Window.Pin());
+
+				// Slate's hit test knows the viewport window under the cursor. Reporting it stops
+				// ImGui inferring it from viewport rects, which strands g.MouseViewport on a
+				// stale viewport and kills hover for every window in another viewport.
+				IO.AddMouseViewportEvent(TargetViewport ? TargetViewport->ID : 0);
 			}
 
 			if (!TargetViewport && !ImGui::IsMouseDown(0))
@@ -294,14 +299,14 @@ public:
 
 		if (Event.IsKeyEvent())
 		{
-			const FImGuiViewportData* FocusedViewport = FindViewportForWindow(LastFocusedWindow.Pin());
+			const ImGuiViewport* FocusedViewport = FindViewportForWindow(LastFocusedWindow.Pin());
 			return FocusedViewport != nullptr;
 		}
 
 		return true;
 	}
 
-	static FImGuiViewportData* FindViewportForWindow(const TSharedPtr<SWindow>& Window)
+	static ImGuiViewport* FindViewportForWindow(const TSharedPtr<SWindow>& Window)
 	{
 		if (!Window.IsValid())
 		{
@@ -310,10 +315,10 @@ public:
 
 		for (ImGuiViewport* Viewport : ImGui::GetPlatformIO().Viewports)
 		{
-			FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(Viewport);
+			const FImGuiViewportData* ViewportData = FImGuiViewportData::GetOrCreate(Viewport);
 			if (ViewportData->Window == Window)
 			{
-				return ViewportData;
+				return Viewport;
 			}
 		}
 


### PR DESCRIPTION
Hover and mouse clicks stop in one region of the screen. The UI continues to
draw. HoveredWindow is NULL. g.MouseViewport points to a viewport that has no
window at the cursor. The error corrects itself when a later frame finds a
viewport.

### Cause: 
the backend never set ImGuiBackendFlags_HasMouseHoveredViewport, so
ImGui inferred the hovered viewport from viewport rects and kept the last one
when that failed.

Without this flag, ImGui infers the hovered viewport from the viewport
rectangles. If the cursor crosses a Slate window that the backend does not
own, the inference fails. Editor notifications, tooltips, and floating tabs
are such windows. After a failure, ImGui keeps the last viewport in
g.MouseViewport. FindHoveredWindowEx() then rejects each window in a
different viewport. As a result, hover and mouse clicks do not reach the UI.

### Fix:
HandleMouseMoveEvent() already finds the viewport under the pointer with the
hit test of Slate. This result is correct, because Slate knows the window
order. The function now returns the ImGuiViewport and reports the ID. The
backend flag tells ImGui to use this ID.
The backend does not report while the pointer is captured. A drag keeps its
target viewport.