### PR TITLE
Reduce input and render latency at low frame rates

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -406,13 +406,17 @@ void FImGuiContext::Initialize()
 	// Ensure main viewport data is created ahead of time
 	FImGuiViewportData::GetOrCreate(ImGui::GetMainViewport());
 
-	FCoreDelegates::OnBeginFrame.AddSP(this, &FImGuiContext::BeginFrame);
+	// FCoreDelegates::OnBeginFrame fires before the engine processes input, causing a one-frame
+	// input delay. Calling FImGuiContext::BeginFrame() during FCoreDelegates::OnSamplingInput
+	// instead ensures the input is fresh, improving UI responsiveness.
+
+	FCoreDelegates::OnSamplingInput.AddSP(this, &FImGuiContext::BeginFrame);
 	FCoreDelegates::OnEndFrame.AddSP(this, &FImGuiContext::EndFrame);
 }
 
 FImGuiContext::~FImGuiContext()
 {
-	FCoreDelegates::OnBeginFrame.RemoveAll(this);
+	FCoreDelegates::OnSamplingInput.RemoveAll(this);
 	FCoreDelegates::OnEndFrame.RemoveAll(this);
 
 	if (FSlateApplication::IsInitialized())
@@ -703,7 +707,7 @@ void FImGuiContext::BeginFrame()
 	ImGui::NewFrame();
 }
 
-void FImGuiContext::EndFrame()
+void FImGuiContext::Render()
 {
 	if (!Context->WithinFrameScope)
 	{
@@ -713,7 +717,6 @@ void FImGuiContext::EndFrame()
 	ImGui::FScopedContext ScopedContext(AsShared());
 
 	ImGui::Render();
-	ImGui::UpdatePlatformWindows();
 
 	for (ImTextureData* TextureData : ImGui::GetPlatformIO().Textures)
 	{
@@ -737,6 +740,37 @@ void FImGuiContext::EndFrame()
 	{
 		ImGui_RenderWindow(ImGui::GetMainViewport(), nullptr);
 		ImGui::RenderPlatformWindowsDefault();
+	}
+}
+
+void FImGuiContext::EndFrame()
+{
+	ImGui::FScopedContext ScopedContext(AsShared());
+
+	// The overlay may not have rendered this frame, for example when its window is
+	// minimized, so make sure the frame is ended before updating the platform windows
+
+	if (Context->WithinFrameScope)
+	{
+		Render();
+	}
+
+	// ImGui::UpdatePlatformWindows() must run exactly once per ended frame: skip when no frame has
+	// run yet (a fresh context starts with the end markers behind FrameCount) and when it already
+	// ran for the current frame count (OnEndFrame can fire without a preceding NewFrame while the
+	// application is shutting down), both of which ImGui::UpdatePlatformWindows() asserts on
+
+	if (Context->FrameCountEnded != Context->FrameCount || Context->FrameCountPlatformEnded >= Context->FrameCount)
+	{
+		return;
+	}
+
+	// Updating platform windows creates, resizes, and shows OS windows, which pumps Win32 messages that can re-enter the
+	// draw pass while the draw buffer is locked, so this must run outside a Slate draw pass, from FCoreDelegates::OnEndFrame
+
+	if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+	{
+		ImGui::UpdatePlatformWindows();
 	}
 }
 

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -346,6 +346,20 @@ SImGuiOverlay::~SImGuiOverlay()
 	}
 }
 
+void SImGuiOverlay::Tick(const FGeometry& AllottedGeometry, double InCurrentTime, float InDeltaTime)
+{
+	SLeafWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
+
+	// FCoreDelegates::OnEndFrame fires after SImGuiOverlay::OnPaint(), causing a one-frame delay due
+	// to stale DrawData. Calling FImGuiContext::Render() here instead (since SImGuiOverlay::Tick()
+	// executes before SImGuiOverlay::OnPaint()) provides fresh DrawData and improves UI responsiveness.
+
+	if (Context.IsValid())
+	{
+		Context->Render();
+	}
+}
+
 int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
 	if (!DrawData.bValid)

--- a/Source/ImGui/Private/SImGuiOverlay.h
+++ b/Source/ImGui/Private/SImGuiOverlay.h
@@ -51,6 +51,7 @@ public:
 	void Construct(const FArguments& Args);
 	virtual ~SImGuiOverlay() override;
 
+	virtual void Tick(const FGeometry& AllottedGeometry, double InCurrentTime, float InDeltaTime) override;
 	virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
 	virtual FVector2D ComputeDesiredSize(float LayoutScaleMultiplier) const override;
 	virtual bool SupportsKeyboardFocus() const override;

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -41,7 +41,10 @@ public:
 	/// Begins a new frame
 	void BeginFrame();
 
-	/// Ends the current frame
+	/// Renders the current frame's UI for display in Slate
+	void Render();
+
+	/// Ends the frame and updates platform windows
 	void EndFrame();
 
 #if WITH_NETIMGUI


### PR DESCRIPTION
At low frame rates, the UI becomes noticeably sluggish due to two separate sources of frame latency:

1. Input Delay: `FCoreDelegates::OnBeginFrame` fires before the engine processes input, causing a one-frame input delay. Calling `FImGuiContext::BeginFrame()` during `FCoreDelegates::OnSamplingInput` instead ensures the input is fresh, and removes that delay.
2. `FCoreDelegates::OnEndFrame` fires after `SImGuiOverlay::OnPaint()`, causing a one-frame delay due to stale
`DrawData`. Extracting the rendering-related part of `FImGuiContext::EndFrame()` into a new
`FImGuiContext::Render()` and calling it from `SImGuiOverlay::Tick()` provides fresh `DrawData` and removes
that delay. The remaining code of `FImGuiContext::EndFrame()` is, as before, called from
`FCoreDelegates::OnEndFrame`, because calling it from `SImGuiOverlay::Tick()` causes ensures.

Both fixes are internal to the plugin and require no changes to user code.