### PR TITLE
Release all pressed keys when focus is lost

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -530,6 +530,16 @@ FImGuiContext::operator ImPlotContext*() const
 }
 #endif
 
+bool FImGuiContext::ShouldClearInputOnFocusLost() const
+{
+	return bClearInputOnFocusLost;
+}
+
+void FImGuiContext::SetClearInputOnFocusLost(bool bClearInput)
+{
+	bClearInputOnFocusLost = bClearInput;
+}
+
 void FImGuiContext::OnDisplayMetricsChanged(const FDisplayMetrics& DisplayMetrics)
 {
 	ImGui::FScopedContext ScopedContext(AsShared());

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -68,6 +68,16 @@ public:
 		else
 		{
 			LastFocusedWindow.Reset();
+
+			ImGui::FScopedContext ScopedContext(Owner->GetContext());
+
+			ImGuiIO& IO = ImGui::GetIO();
+
+			// Release all pressed keys when focus is lost, otherwise they remain pressed.
+
+			IO.ClearEventsQueue();
+			IO.ClearInputKeys();
+			IO.ClearInputMouse();
 		}
 	}
 

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -71,13 +71,16 @@ public:
 
 			ImGui::FScopedContext ScopedContext(Owner->GetContext());
 
-			ImGuiIO& IO = ImGui::GetIO();
+			if (ScopedContext->ShouldClearInputOnFocusLost())
+			{
+				ImGuiIO& IO = ImGui::GetIO();
 
-			// Release all pressed keys when focus is lost, otherwise they remain pressed.
+				// Release all pressed keys when focus is lost, otherwise they remain pressed.
 
-			IO.ClearEventsQueue();
-			IO.ClearInputKeys();
-			IO.ClearInputMouse();
+				IO.ClearEventsQueue();
+				IO.ClearInputKeys();
+				IO.ClearInputMouse();
+			}
 		}
 	}
 

--- a/Source/ImGui/Public/ImGuiContext.h
+++ b/Source/ImGui/Public/ImGuiContext.h
@@ -63,6 +63,15 @@ public:
 	operator ImPlotContext*() const;
 #endif
 
+	/// Returns true if pressed input keys are released when the Slate window loses focus.
+	bool ShouldClearInputOnFocusLost() const;
+
+	/// Sets whether input keys are released when the Slate window loses focus.
+	/// @note Useful when programmatically changing focus, such as clearing and immediately restoring
+	/// keyboard focus to switch input modes (as UConsole::FakeGotoState() does). Disable this
+	/// temporarily to prevent input keys currently held by the user from being prematurely released.
+	void SetClearInputOnFocusLost(bool bClearInput);
+
 private:
 	void Initialize();
 
@@ -93,6 +102,8 @@ private:
 #endif
 
 	TArray<FTextureRef> Textures;
+
+	bool bClearInputOnFocusLost = true;
 };
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
When Slate focus changes to an invalid widget path - Dear ImGui never gets the matching key/button release events, so any keys or mouse buttons held at that moment remain pressed. This can happen when the user presses `Shift + F1` in PIE.

`FImGuiInputProcessor::OnFocusChanging()` now clears the Dear ImGui input state when it resets `LastFocusedWindow`.

`FImGuiContext::SetClearInputOnFocusLost()` allows this clearing to be temporarily disabled. This is useful when programmatically changing focus, such as clearing and immediately restoring keyboard focus to switch input modes (as `UConsole::FakeGotoState()` does).