### PR TITLE
Fix plugin not saving its .ini files in Unreal programs

### DIFF
--- a/Source/ImGui/Private/ImGuiConfig.cpp
+++ b/Source/ImGui/Private/ImGuiConfig.cpp
@@ -5,6 +5,7 @@
 #include <InputCoreTypes.h>
 #include <Framework/Commands/InputChord.h>
 #include <HAL/PlatformFileManager.h>
+#include <Misc/Paths.h>
 
 #if WITH_ENGINE
 #include <Engine/Texture2D.h>
@@ -63,7 +64,20 @@ ImFileHandle ImFileOpen(const char* FileName, const char* Mode)
 
 	if (bWrite || bAppend || bExtended)
 	{
-		return PlatformFile.OpenWrite(UTF8_TO_TCHAR(FileName), bAppend, bExtended);
+		const FString FilePath = UTF8_TO_TCHAR(FileName);
+
+		if (bWrite || bAppend)
+		{
+			const FString Directory = FPaths::GetPath(FilePath);
+			if (!Directory.IsEmpty())
+			{
+				// IPlatformFile::OpenWrite() does not create missing parent directories, and it fails if the
+				// directory does not exist, so we create the directory explicitly before opening the file.
+				PlatformFile.CreateDirectoryTree(*Directory);
+			}
+		}
+
+		return PlatformFile.OpenWrite(*FilePath, bAppend, bExtended);
 	}
 
 	if (bRead)


### PR DESCRIPTION
`IPlatformFile::OpenWrite()` does not create missing parent directories and fails if the directory does not exist, so `.ini` files are never saved.

I modified `ImFileOpen()` to automatically create the required folders before writing to the file.