### PR TITLE
Skip ImGui::NewFrame() while ImGuiIO::DisplaySize is invalid

### DIFF
--- a/Source/ImGui/Private/ImGuiContext.cpp
+++ b/Source/ImGui/Private/ImGuiContext.cpp
@@ -700,7 +700,14 @@ void FImGuiContext::BeginFrame()
 	IO.DeltaTime = FApp::GetDeltaTime();
 	IO.DisplaySize = ImGui_GetWindowSize(ImGui::GetMainViewport());
 
-	ImGui::NewFrame();
+	// Skip rendering while DisplaySize is invalid (i.e. SImGuiOverlay has no valid geometry yet), because
+	// restoring windows from the .ini would then place them at wrong absolute positions. This only applies to
+	// the first frame; otherwise SImGuiWindow left behind after PIE ends would remain alive forever.
+
+	if (Context->FrameCount > 0 || (IO.DisplaySize.x > 0.0f && IO.DisplaySize.y > 0.0f))
+	{
+		ImGui::NewFrame();
+	}
 }
 
 void FImGuiContext::EndFrame()


### PR DESCRIPTION
The first frame could begin before `SImGuiOverlay` has any valid geometry, so `DisplaySize` will be invalid and windows restored from the `.ini` in that frame will end up in the wrong places.

I modified `FImGuiContext::BeginFrame()` to skip `ImGui::NewFrame()` while `DisplaySize` is invalid. The skip is limited to the first frame only, because if it continued after PIE ends, the active `SImGuiWindows` would never be destroyed and would remain hanging forever.