### PR TITLE
Add a native rendering path via a custom Slate element

### DIFF
--- a/ImGui.uplugin
+++ b/ImGui.uplugin
@@ -11,6 +11,11 @@
 	"MarketplaceURL": "",
 	"Modules": [
 		{
+			"Name": "ImGuiShaders",
+			"Type": "Runtime",
+			"LoadingPhase": "PostConfigInit"
+		},
+		{
 			"Name": "ImGui",
 			"Type": "Runtime",
 			"LoadingPhase": "Default"

--- a/Shaders/Private/ImGui.usf
+++ b/Shaders/Private/ImGui.usf
@@ -1,0 +1,37 @@
+#include "/Engine/Private/Common.ush"
+#include "/Engine/Private/GammaCorrectionCommon.ush"
+
+float4x4 ProjectionMatrix;
+
+void MainVS(
+	in float2 InPosition : ATTRIBUTE0,
+	in float2 InUV : ATTRIBUTE1,
+	in float4 InColor : ATTRIBUTE2,
+	out float4 OutPosition : SV_POSITION,
+	out float2 OutUV : TEXCOORD0,
+	out float4 OutColor : COLOR0)
+{
+	OutPosition = mul(float4(InPosition, 0, 1), ProjectionMatrix);
+	OutUV = InUV;
+	OutColor = InColor;
+}
+
+Texture2D Texture;
+SamplerState TextureSampler;
+bool bSrgb;
+
+void MainPS(
+	in float4 InPosition : SV_POSITION,
+	in float2 InUV : TEXCOORD0,
+	in float4 InColor : COLOR0,
+	out float4 OutColor : SV_Target0)
+{
+	float4 TextureColor = Texture2DSample(Texture, TextureSampler, InUV);
+
+	if (bSrgb)
+	{
+		TextureColor.rgb = LinearToSrgb(TextureColor.rgb);
+	}
+
+	OutColor = InColor * TextureColor;
+}

--- a/Source/ImGui/ImGui.Build.cs
+++ b/Source/ImGui/ImGui.Build.cs
@@ -4,6 +4,7 @@ public class ImGui : ModuleRules
 {
 	protected virtual bool WithImPlot => true;
 	protected virtual bool WithNetImGui => true;
+	protected virtual bool WithNativeRendering => Target.bCompileAgainstEngine;
 
 	public ImGui(ReadOnlyTargetRules Target) : base(Target)
 	{
@@ -63,6 +64,22 @@ public class ImGui : ModuleRules
 		else
 		{
 			PublicDefinitions.Add("WITH_NETIMGUI=0");
+		}
+
+		if (WithNativeRendering)
+		{
+			PrivateDependencyModuleNames.AddRange(new[]
+			{
+				"RHI",
+				"RenderCore",
+				"ImGuiShaders"
+			});
+
+			PublicDefinitions.Add("WITH_IMGUI_NATIVE_RENDERING=1");
+		}
+		else
+		{
+			PublicDefinitions.Add("WITH_IMGUI_NATIVE_RENDERING=0");
 		}
 	}
 }

--- a/Source/ImGui/Private/ImGuiDrawData.cpp
+++ b/Source/ImGui/Private/ImGuiDrawData.cpp
@@ -1,0 +1,32 @@
+#include "ImGuiDrawData.h"
+
+#ifndef IMGUI_DISABLE
+
+void FImGuiDrawList::Update(ImDrawList* Source)
+{
+	VtxBuffer.swap(Source->VtxBuffer);
+	IdxBuffer.swap(Source->IdxBuffer);
+	CmdBuffer.swap(Source->CmdBuffer);
+	Flags = Source->Flags;
+}
+
+void FImGuiDrawData::Update(ImDrawData* Source)
+{
+	bValid = Source->Valid;
+
+	TotalIdxCount = Source->TotalIdxCount;
+	TotalVtxCount = Source->TotalVtxCount;
+
+	DrawLists.SetNum(Source->CmdLists.Size);
+
+	for (int32 ListIdx = 0; ListIdx < DrawLists.Num(); ++ListIdx)
+	{
+		DrawLists[ListIdx].Update(Source->CmdLists[ListIdx]);
+	}
+
+	DisplayPos = Source->DisplayPos;
+	DisplaySize = Source->DisplaySize;
+	FrameBufferScale = Source->FramebufferScale;
+}
+
+#endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/ImGuiDrawData.h
+++ b/Source/ImGui/Private/ImGuiDrawData.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifndef IMGUI_DISABLE
+
+#include <Math/Vector2D.h>
+
+THIRD_PARTY_INCLUDES_START
+#include <imgui.h>
+THIRD_PARTY_INCLUDES_END
+
+struct FImGuiDrawList
+{
+	void Update(ImDrawList* Source);
+
+	ImVector<ImDrawVert> VtxBuffer;
+	ImVector<ImDrawIdx> IdxBuffer;
+	ImVector<ImDrawCmd> CmdBuffer;
+	ImDrawListFlags Flags = ImDrawListFlags_None;
+};
+
+struct FImGuiDrawData
+{
+	void Update(ImDrawData* Source);
+
+	bool bValid = false;
+
+	int32 TotalIdxCount = 0;
+	int32 TotalVtxCount = 0;
+
+	TArray<FImGuiDrawList> DrawLists;
+
+	FVector2f DisplayPos = FVector2f::ZeroVector;
+	FVector2f DisplaySize = FVector2f::ZeroVector;
+	FVector2f FrameBufferScale = FVector2f::ZeroVector;
+};
+
+#endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/ImGuiSlateElement.cpp
+++ b/Source/ImGui/Private/ImGuiSlateElement.cpp
@@ -1,0 +1,268 @@
+#include "ImGuiSlateElement.h"
+
+#ifndef IMGUI_DISABLE
+
+#if WITH_IMGUI_NATIVE_RENDERING
+
+#include <GlobalRenderResources.h>
+#include <PipelineStateCache.h>
+#include <RenderGraphBuilder.h>
+#include <RHIStaticStates.h>
+#include <TextureResource.h>
+#include <Engine/Texture.h>
+
+#include "ImGuiShaders.h"
+
+BEGIN_SHADER_PARAMETER_STRUCT(FImGuiPassParameters, )
+	RENDER_TARGET_BINDING_SLOTS()
+END_SHADER_PARAMETER_STRUCT()
+
+class FImGuiVertexDeclaration : public FRenderResource
+{
+public:
+	FVertexDeclarationRHIRef VertexDeclarationRHI;
+
+	virtual void InitRHI(FRHICommandListBase& RHICmdList) override
+	{
+		constexpr size_t Stride = sizeof(ImDrawVert);
+
+		FVertexDeclarationElementList Elements;
+		Elements.Add(FVertexElement(0, STRUCT_OFFSET(ImDrawVert, pos), VET_Float2, 0, Stride));
+		Elements.Add(FVertexElement(0, STRUCT_OFFSET(ImDrawVert, uv), VET_Float2, 1, Stride));
+		Elements.Add(FVertexElement(0, STRUCT_OFFSET(ImDrawVert, col), VET_Color, 2, Stride));
+
+		VertexDeclarationRHI = PipelineStateCache::GetOrCreateVertexDeclaration(Elements);
+	}
+
+	virtual void ReleaseRHI() override
+	{
+		VertexDeclarationRHI.SafeRelease();
+	}
+};
+
+static TGlobalResource<FImGuiVertexDeclaration, FRenderResource::EInitPhase::Pre> GImGuiVertexDeclaration;
+
+void FImGuiSlateElement::Draw_RenderThread(FRDGBuilder& GraphBuilder, const FDrawPassInputs& Inputs)
+{
+	if (!DrawData.bValid || DrawData.TotalVtxCount <= 0 || DrawData.TotalIdxCount <= 0 || Inputs.OutputTexture == nullptr)
+	{
+		return;
+	}
+
+	RDG_EVENT_SCOPE(GraphBuilder, "ImGui");
+
+	FImGuiPassParameters* PassParameters = GraphBuilder.AllocParameters<FImGuiPassParameters>();
+	PassParameters->RenderTargets[0] = FRenderTargetBinding(Inputs.OutputTexture, ERenderTargetLoadAction::ELoad);
+
+	const FIntPoint ViewExtent = Inputs.OutputTexture->Desc.Extent;
+	const FIntRect ViewRect(0, 0, ViewExtent.X, ViewExtent.Y);
+
+	FIntRect ClippingRect = Inputs.SceneViewRect;
+	if (ClippingRect.IsEmpty())
+	{
+		ClippingRect.Max = ViewExtent;
+	}
+
+	// ImGui positions are defined relative to the viewport origin, so we need to offset everything by the widget's position.
+
+	const FVector2f DrawOffset(Geometry.GetAccumulatedRenderTransform().GetTranslation() - FVector2D(DrawData.DisplayPos));
+
+	const FVector2f ScissorOffset = DrawOffset + Inputs.ElementsOffset;
+
+	// Slate has already baked ElementsOffset into ElementsMatrix, so only the scissor offset carries it.
+	const FMatrix44f ProjectionMatrix = FTranslationMatrix44f::Make(FVector3f(DrawOffset, 0.0f)) * Inputs.ElementsMatrix;
+
+	GraphBuilder.AddPass(
+		RDG_EVENT_NAME("ImGui"),
+		PassParameters,
+		ERDGPassFlags::Raster,
+		[this, ViewRect, ClippingRect, ScissorOffset, ProjectionMatrix](FRHICommandList& RHICmdList)
+		{
+			const FGlobalShaderMap* ShaderMap = GetGlobalShaderMap(GMaxRHIFeatureLevel);
+			TShaderMapRef<FImGuiVertexShader> VertexShader(ShaderMap);
+			TShaderMapRef<FImGuiPixelShader> PixelShader(ShaderMap);
+
+			RHICmdList.SetViewport(ViewRect.Min.X, ViewRect.Min.Y, 0.0f, ViewRect.Max.X, ViewRect.Max.Y, 1.0f);
+
+			FGraphicsPipelineStateInitializer GraphicsPSOInit;
+			RHICmdList.ApplyCachedRenderTargets(GraphicsPSOInit);
+
+			GraphicsPSOInit.BoundShaderState.VertexDeclarationRHI = GImGuiVertexDeclaration.VertexDeclarationRHI;
+			GraphicsPSOInit.BoundShaderState.VertexShaderRHI = VertexShader.GetVertexShader();
+			GraphicsPSOInit.BoundShaderState.PixelShaderRHI = PixelShader.GetPixelShader();
+			GraphicsPSOInit.BlendState = TStaticBlendState<CW_RGBA, BO_Add, BF_SourceAlpha, BF_InverseSourceAlpha, BO_Add, BF_One, BF_InverseSourceAlpha>::GetRHI();
+			GraphicsPSOInit.RasterizerState = TStaticRasterizerState<>::GetRHI();
+			GraphicsPSOInit.DepthStencilState = TStaticDepthStencilState<false, CF_Always>::GetRHI();
+			GraphicsPSOInit.PrimitiveType = PT_TriangleList;
+
+			SetGraphicsPipelineState(RHICmdList, GraphicsPSOInit, 0);
+
+			{
+				FRHIBatchedShaderParameters& BatchedParameters = RHICmdList.GetScratchShaderParameters();
+
+				VertexShader->SetProjectionMatrix(BatchedParameters, ProjectionMatrix);
+				RHICmdList.SetBatchedShaderParameters(VertexShader.GetVertexShader(), BatchedParameters);
+			}
+
+			const FRHIBufferCreateDesc VertexBufferDesc = FRHIBufferCreateDesc::CreateVertex<ImDrawVert>(
+				                                        TEXT("ImGuiVertexBuffer"), static_cast<uint32>(DrawData.TotalVtxCount))
+			                                              .AddUsage(EBufferUsageFlags::Volatile)
+			                                              .SetInitialState(ERHIAccess::VertexOrIndexBuffer)
+			                                              .SetInitActionInitializer();
+
+			TRHIBufferInitializer<ImDrawVert> VertexBufferInitializer = RHICmdList.CreateBufferInitializer(VertexBufferDesc);
+
+			const FRHIBufferCreateDesc IndexBufferDesc = FRHIBufferCreateDesc::CreateIndex<ImDrawIdx>(
+				                                       TEXT("ImGuiIndexBuffer"), static_cast<uint32>(DrawData.TotalIdxCount))
+			                                             .AddUsage(EBufferUsageFlags::Volatile)
+			                                             .SetInitialState(ERHIAccess::VertexOrIndexBuffer)
+			                                             .SetInitActionInitializer();
+
+			TRHIBufferInitializer<ImDrawIdx> IndexBufferInitializer = RHICmdList.CreateBufferInitializer(IndexBufferDesc);
+
+			uint32 VertexOffset = 0;
+			uint32 IndexOffset = 0;
+
+			for (const FImGuiDrawList& DrawList : DrawData.DrawLists)
+			{
+				if (DrawList.VtxBuffer.Size > 0 && DrawList.IdxBuffer.Size > 0)
+				{
+					VertexBufferInitializer.WriteArray(VertexOffset, MakeConstArrayView(DrawList.VtxBuffer.Data, DrawList.VtxBuffer.Size));
+					IndexBufferInitializer.WriteArray(IndexOffset, MakeConstArrayView(DrawList.IdxBuffer.Data, DrawList.IdxBuffer.Size));
+				}
+
+				// The draw loop below must increment the offsets in exactly the same way.
+
+				VertexOffset += DrawList.VtxBuffer.Size;
+				IndexOffset += DrawList.IdxBuffer.Size;
+			}
+
+			const FBufferRHIRef IndexBuffer = IndexBufferInitializer.Finalize();
+			RHICmdList.SetStreamSource(0, VertexBufferInitializer.Finalize(), 0);
+
+			FRHISamplerState* DefaultSampler = TStaticSamplerState<SF_Bilinear, AM_Wrap, AM_Wrap, AM_Wrap>::GetRHI();
+
+			FRHITexture* CurrentTexture = nullptr;
+			FIntRect CurrentScissorRect;
+
+			int32 TextureResourceIdx = -1;
+
+			VertexOffset = 0;
+			IndexOffset = 0;
+
+			for (int32 ListIdx = 0; ListIdx < DrawData.DrawLists.Num(); ++ListIdx)
+			{
+				const FImGuiDrawList& DrawList = DrawData.DrawLists[ListIdx];
+
+				for (int32 CmdIdx = 0; CmdIdx < DrawList.CmdBuffer.Size; ++CmdIdx)
+				{
+					TextureResourceIdx += 1;
+
+					const ImDrawCmd& DrawCmd = DrawList.CmdBuffer[CmdIdx];
+
+					if (DrawCmd.UserCallback != nullptr || DrawCmd.ElemCount == 0)
+					{
+						continue;
+					}
+
+					// Clamped the way Slate clamps its own clipping rects, see SetSlateClipping().
+
+					const int32 ScissorMinX = FMath::Clamp(FMath::FloorToInt(DrawCmd.ClipRect.x + ScissorOffset.X), ClippingRect.Min.X, ClippingRect.Max.X);
+					const int32 ScissorMinY = FMath::Clamp(FMath::FloorToInt(DrawCmd.ClipRect.y + ScissorOffset.Y), ClippingRect.Min.Y, ClippingRect.Max.Y);
+					const int32 ScissorMaxX = FMath::Clamp(FMath::CeilToInt(DrawCmd.ClipRect.z + ScissorOffset.X), ScissorMinX, ClippingRect.Max.X);
+					const int32 ScissorMaxY = FMath::Clamp(FMath::CeilToInt(DrawCmd.ClipRect.w + ScissorOffset.Y), ScissorMinY, ClippingRect.Max.Y);
+
+					if (ScissorMaxX <= ScissorMinX || ScissorMaxY <= ScissorMinY)
+					{
+						continue;
+					}
+
+					FRHITexture* Texture = GWhiteTexture->TextureRHI;
+					FRHISamplerState* Sampler = DefaultSampler;
+					bool bSRGB = false;
+
+					if (TextureResources.IsValidIndex(TextureResourceIdx))
+					{
+						const FTextureResource* TextureResource = TextureResources[TextureResourceIdx];
+						if (TextureResource != nullptr && TextureResource->TextureRHI.IsValid())
+						{
+							Texture = TextureResource->TextureRHI.GetReference();
+							bSRGB = TextureResource->bSRGB;
+
+							if (TextureResource->SamplerStateRHI.IsValid())
+							{
+								Sampler = TextureResource->SamplerStateRHI.GetReference();
+							}
+						}
+					}
+
+					if (CurrentTexture != Texture)
+					{
+						CurrentTexture = Texture;
+
+						FRHIBatchedShaderParameters& BatchedParameters = RHICmdList.GetScratchShaderParameters();
+						PixelShader->SetTexture(BatchedParameters, Texture, Sampler, bSRGB);
+						RHICmdList.SetBatchedShaderParameters(PixelShader.GetPixelShader(), BatchedParameters);
+					}
+
+					const FIntRect ScissorRect(ScissorMinX, ScissorMinY, ScissorMaxX, ScissorMaxY);
+					if (CurrentScissorRect != ScissorRect)
+					{
+						CurrentScissorRect = ScissorRect;
+
+						RHICmdList.SetScissorRect(true, ScissorMinX, ScissorMinY, ScissorMaxX, ScissorMaxY);
+					}
+
+					RHICmdList.DrawIndexedPrimitive(
+						IndexBuffer, VertexOffset + DrawCmd.VtxOffset, 0,
+						static_cast<uint32>(DrawList.VtxBuffer.Size) - DrawCmd.VtxOffset,
+						IndexOffset + DrawCmd.IdxOffset, DrawCmd.ElemCount / 3, 1);
+				}
+
+				VertexOffset += DrawList.VtxBuffer.Size;
+				IndexOffset += DrawList.IdxBuffer.Size;
+			}
+
+			RHICmdList.SetScissorRect(false, 0, 0, 0, 0);
+		});
+}
+
+void FImGuiSlateElement::SetDrawData_GameThread(ImDrawData* InDrawData)
+{
+	DrawData.Update(InDrawData);
+
+	TextureResources.Reset();
+
+	if (!DrawData.bValid || GExitPurge)
+	{
+		return;
+	}
+
+	for (int32 ListIdx = 0; ListIdx < DrawData.DrawLists.Num(); ++ListIdx)
+	{
+		const FImGuiDrawList& DrawList = DrawData.DrawLists[ListIdx];
+
+		for (const ImDrawCmd& DrawCmd : DrawList.CmdBuffer)
+		{
+			UTexture* Texture = DrawCmd.GetTexID();
+			FTextureResource* TextureResource = IsValid(Texture) ? Texture->GetResource() : nullptr;
+
+			if (TextureResource != nullptr)
+			{
+				// Keep texture streaming from dropping the higher detail mips.
+				TextureResource->LastRenderTime = FApp::GetCurrentTime();
+			}
+
+			TextureResources.Emplace(TextureResource);
+		}
+	}
+}
+
+void FImGuiSlateElement::SetGeometry_GameThread(const FGeometry& InGeometry)
+{
+	Geometry = InGeometry;
+}
+
+#endif // #if WITH_IMGUI_NATIVE_RENDERING
+
+#endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/ImGuiSlateElement.h
+++ b/Source/ImGui/Private/ImGuiSlateElement.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifndef IMGUI_DISABLE
+
+#if WITH_IMGUI_NATIVE_RENDERING
+
+#include <Rendering/RenderingCommon.h>
+
+#include "ImGuiDrawData.h"
+
+class FTextureResource;
+
+/// Renders ImGui draw data with native RHI draw calls, bypassing the Slate vertex batcher.
+class FImGuiSlateElement : public ICustomSlateElement
+{
+public:
+	virtual void Draw_RenderThread(FRDGBuilder& GraphBuilder, const FDrawPassInputs& Inputs) override;
+
+	void SetDrawData_GameThread(ImDrawData* InDrawData);
+
+	void SetGeometry_GameThread(const FGeometry& InGeometry);
+
+private:
+	FImGuiDrawData DrawData;
+
+	FGeometry Geometry;
+
+	TArray<const FTextureResource*> TextureResources;
+};
+
+#endif // #if WITH_IMGUI_NATIVE_RENDERING
+
+#endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/SImGuiOverlay.cpp
+++ b/Source/ImGui/Private/SImGuiOverlay.cpp
@@ -4,29 +4,15 @@
 
 #include <Framework/Application/SlateApplication.h>
 
+#if WITH_IMGUI_NATIVE_RENDERING
+#include <RenderingThread.h>
+#endif
+
 #include "ImGuiContext.h"
 
-FImGuiDrawList::FImGuiDrawList(ImDrawList* Source)
-{
-	VtxBuffer.swap(Source->VtxBuffer);
-	IdxBuffer.swap(Source->IdxBuffer);
-	CmdBuffer.swap(Source->CmdBuffer);
-	Flags = Source->Flags;
-}
-
-FImGuiDrawData::FImGuiDrawData(const ImDrawData* Source)
-{
-	bValid = Source->Valid;
-
-	TotalIdxCount = Source->TotalIdxCount;
-	TotalVtxCount = Source->TotalVtxCount;
-
-	ImGui::CopyArray(Source->CmdLists, DrawLists);
-
-	DisplayPos = Source->DisplayPos;
-	DisplaySize = Source->DisplaySize;
-	FrameBufferScale = Source->FramebufferScale;
-}
+#if WITH_IMGUI_NATIVE_RENDERING
+#include "ImGuiSlateElement.h"
+#endif
 
 class FImGuiInputProcessor : public IInputProcessor
 {
@@ -336,6 +322,13 @@ void SImGuiOverlay::Construct(const FArguments& Args)
 		InputProcessor = MakeShared<FImGuiInputProcessor>(this);
 		FSlateApplication::Get().RegisterInputPreProcessor(InputProcessor.ToSharedRef(), 0);
 	}
+
+#if WITH_IMGUI_NATIVE_RENDERING
+	for (TSharedPtr<FImGuiSlateElement>& SlateElement : SlateElements)
+	{
+		SlateElement = MakeShared<FImGuiSlateElement>();
+	}
+#endif
 }
 
 SImGuiOverlay::~SImGuiOverlay()
@@ -344,10 +337,36 @@ SImGuiOverlay::~SImGuiOverlay()
 	{
 		FSlateApplication::Get().UnregisterInputPreProcessor(InputProcessor);
 	}
+
+#if WITH_IMGUI_NATIVE_RENDERING
+	// Slate may still hold these elements in an undrawn render batch, so
+	// hand them over to the render thread instead of releasing them here.
+
+	ENQUEUE_RENDER_COMMAND(ReleaseImGuiSlateElement)([SlateElements = MoveTemp(SlateElements)](FRHICommandListImmediate& RHICmdList) mutable
+	{
+		for (TSharedPtr<FImGuiSlateElement>& SlateElement : SlateElements)
+		{
+			SlateElement.Reset();
+		}
+	});
+#endif
 }
 
 int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
+#if WITH_IMGUI_NATIVE_RENDERING
+	const TSharedPtr<FImGuiSlateElement>& SlateElement = SlateElements[CurrentSlateElementIdx];
+	if (SlateElement.IsValid())
+	{
+		SlateElement->SetGeometry_GameThread(AllottedGeometry);
+
+		OutDrawElements.PushClip(FSlateClippingZone(MyCullingRect));
+		FSlateDrawElement::MakeCustom(OutDrawElements, LayerId, SlateElement);
+		OutDrawElements.PopClip();
+	}
+
+	return LayerId;
+#else
 	if (!DrawData.bValid)
 	{
 		return LayerId;
@@ -432,6 +451,7 @@ int32 SImGuiOverlay::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGe
 	}
 
 	return LayerId;
+#endif
 }
 
 FVector2D SImGuiOverlay::ComputeDesiredSize(float LayoutScaleMultiplier) const
@@ -460,9 +480,20 @@ TSharedPtr<FImGuiContext> SImGuiOverlay::GetContext() const
 	return Context;
 }
 
-void SImGuiOverlay::SetDrawData(const ImDrawData* InDrawData)
+void SImGuiOverlay::SetDrawData(ImDrawData* InDrawData)
 {
-	DrawData = FImGuiDrawData(InDrawData);
+#if WITH_IMGUI_NATIVE_RENDERING
+	// Rotate to the next element so the render thread keeps reading the previous frame's data undisturbed.
+	CurrentSlateElementIdx = (CurrentSlateElementIdx + 1) % SlateElementCount;
+
+	const TSharedPtr<FImGuiSlateElement>& SlateElement = SlateElements[CurrentSlateElementIdx];
+	if (SlateElement.IsValid())
+	{
+		SlateElement->SetDrawData_GameThread(InDrawData);
+	}
+#else
+	DrawData.Update(InDrawData);
+#endif
 }
 
 #endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGui/Private/SImGuiOverlay.h
+++ b/Source/ImGui/Private/SImGuiOverlay.h
@@ -5,37 +5,9 @@
 #include <Framework/Application/IInputProcessor.h>
 #include <Widgets/SLeafWidget.h>
 
-THIRD_PARTY_INCLUDES_START
-#include <imgui.h>
-THIRD_PARTY_INCLUDES_END
+#include "ImGuiDrawData.h"
 
-struct FImGuiDrawList
-{
-	FImGuiDrawList() = default;
-	explicit FImGuiDrawList(ImDrawList* Source);
-
-	ImVector<ImDrawVert> VtxBuffer;
-	ImVector<ImDrawIdx> IdxBuffer;
-	ImVector<ImDrawCmd> CmdBuffer;
-	ImDrawListFlags Flags = ImDrawListFlags_None;
-};
-
-struct FImGuiDrawData
-{
-	FImGuiDrawData() = default;
-	explicit FImGuiDrawData(const ImDrawData* Source);
-
-	bool bValid = false;
-
-	int32 TotalIdxCount = 0;
-	int32 TotalVtxCount = 0;
-
-	TArray<FImGuiDrawList> DrawLists;
-
-	FVector2f DisplayPos = FVector2f::ZeroVector;
-	FVector2f DisplaySize = FVector2f::ZeroVector;
-	FVector2f FrameBufferScale = FVector2f::ZeroVector;
-};
+class FImGuiSlateElement;
 
 class SImGuiOverlay : public SLeafWidget
 {
@@ -57,12 +29,22 @@ public:
 	virtual FReply OnKeyChar(const FGeometry& MyGeometry, const FCharacterEvent& Event) override;
 
 	TSharedPtr<FImGuiContext> GetContext() const;
-	void SetDrawData(const ImDrawData* InDrawData);
+	void SetDrawData(ImDrawData* InDrawData);
 
 private:
 	TSharedPtr<FImGuiContext> Context = nullptr;
 	TSharedPtr<IInputProcessor> InputProcessor = nullptr;
+
+#if WITH_IMGUI_NATIVE_RENDERING
+	/// Number of Slate elements to rotate between; two are enough to keep the render thread from
+	/// reading the element the game thread is writing to, as it never trails by more than a frame.
+	static constexpr int32 SlateElementCount = 2;
+
+	TStaticArray<TSharedPtr<FImGuiSlateElement>, SlateElementCount> SlateElements;
+	int32 CurrentSlateElementIdx = 0;
+#else
 	FImGuiDrawData DrawData;
+#endif
 };
 
 #endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGuiShaders/ImGuiShaders.Build.cs
+++ b/Source/ImGuiShaders/ImGuiShaders.Build.cs
@@ -1,0 +1,20 @@
+using UnrealBuildTool;
+
+public class ImGuiShaders : ModuleRules
+{
+	public ImGuiShaders(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new[]
+		{
+			"Core",
+			"RenderCore"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new[]
+		{
+			"Projects"
+		});
+	}
+}

--- a/Source/ImGuiShaders/Private/ImGuiShaders.cpp
+++ b/Source/ImGuiShaders/Private/ImGuiShaders.cpp
@@ -1,0 +1,52 @@
+#include "ImGuiShaders.h"
+
+#ifndef IMGUI_DISABLE
+
+#include <Interfaces/IPluginManager.h>
+
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_MODULE(FImGuiShadersModule, ImGuiShaders)
+
+IMPLEMENT_GLOBAL_SHADER(FImGuiVertexShader, "/Plugin/ImGui/Private/ImGui.usf", "MainVS", SF_Vertex);
+IMPLEMENT_GLOBAL_SHADER(FImGuiPixelShader, "/Plugin/ImGui/Private/ImGui.usf", "MainPS", SF_Pixel);
+
+void FImGuiShadersModule::StartupModule()
+{
+	const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("ImGui"));
+	if (Plugin.IsValid())
+	{
+		AddShaderSourceDirectoryMapping(TEXT("/Plugin/ImGui"), FPaths::Combine(Plugin->GetBaseDir(), TEXT("Shaders")));
+	}
+}
+
+FImGuiVertexShader::FImGuiVertexShader(const ShaderMetaType::CompiledShaderInitializerType& Initializer) : FGlobalShader(Initializer)
+{
+	ProjectionMatrix.Bind(Initializer.ParameterMap, TEXT("ProjectionMatrix"));
+}
+
+void FImGuiVertexShader::SetProjectionMatrix(FRHIBatchedShaderParameters& BatchedParameters, const FMatrix44f& InProjectionMatrix)
+{
+	SetShaderValue(BatchedParameters, ProjectionMatrix, InProjectionMatrix);
+}
+
+FImGuiPixelShader::FImGuiPixelShader(const ShaderMetaType::CompiledShaderInitializerType& Initializer) : FGlobalShader(Initializer)
+{
+	Texture.Bind(Initializer.ParameterMap, TEXT("Texture"));
+	TextureSampler.Bind(Initializer.ParameterMap, TEXT("TextureSampler"));
+	bSrgb.Bind(Initializer.ParameterMap, TEXT("bSrgb"));
+}
+
+void FImGuiPixelShader::SetTexture(FRHIBatchedShaderParameters& BatchedParameters, FRHITexture* InTexture, FRHISamplerState* InSampler, bool bInSrgb)
+{
+	SetTextureParameter(BatchedParameters, Texture, TextureSampler, InSampler, InTexture);
+	SetShaderValue(BatchedParameters, bSrgb, bInSrgb);
+}
+
+#else // #ifndef IMGUI_DISABLE
+
+#include <Modules/ModuleManager.h>
+
+IMPLEMENT_MODULE(FDefaultModuleImpl, ImGuiShaders);
+
+#endif // #ifndef IMGUI_DISABLE

--- a/Source/ImGuiShaders/Public/ImGuiShaders.h
+++ b/Source/ImGuiShaders/Public/ImGuiShaders.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifndef IMGUI_DISABLE
+
+#include <GlobalShader.h>
+
+class FImGuiShadersModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+};
+
+class IMGUISHADERS_API FImGuiVertexShader : public FGlobalShader
+{
+	DECLARE_GLOBAL_SHADER(FImGuiVertexShader);
+
+public:
+	FImGuiVertexShader() = default;
+
+	explicit FImGuiVertexShader(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
+
+	void SetProjectionMatrix(FRHIBatchedShaderParameters& BatchedParameters, const FMatrix44f& InProjectionMatrix);
+
+private:
+	LAYOUT_FIELD(FShaderParameter, ProjectionMatrix);
+};
+
+class IMGUISHADERS_API FImGuiPixelShader : public FGlobalShader
+{
+	DECLARE_GLOBAL_SHADER(FImGuiPixelShader);
+
+public:
+	FImGuiPixelShader() = default;
+
+	explicit FImGuiPixelShader(const ShaderMetaType::CompiledShaderInitializerType& Initializer);
+
+	void SetTexture(FRHIBatchedShaderParameters& BatchedParameters, FRHITexture* InTexture, FRHISamplerState* InSampler, bool bInSrgb);
+
+private:
+	LAYOUT_FIELD(FShaderResourceParameter, Texture);
+	LAYOUT_FIELD(FShaderResourceParameter, TextureSampler);
+	LAYOUT_FIELD(FShaderParameter, bSrgb);
+};
+
+#endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
The Slate rendering path struggles with the amount of vertices ImGui can generate: if you open ImPlot Demo, select the Subplots tab and expand all dropdowns, ImGui starts generating more than 100k vertices in a single frame, Slate spends too much time allocating buffers for them, ands the frame rate drops significantly.

To fix that, I added `FImGuiSlateElement`, an `ICustomSlateElement` that renders ImGui draw data on the render thread with direct RHI draw calls. The native path is enabled whenever the target compiles against the engine, and the old Slate path remains available under `WITH_IMGUI_NATIVE_RENDERING=0`.